### PR TITLE
Fix installation through fisherman

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gets you to a parent folder, heavily inspired by the plugin [upto](https://githu
 With [fisherman]
 
 ```
-fisher markcial/upto
+fisher add markcial/upto
 ```
 
 ## Usage


### PR DESCRIPTION
I added the correct line to use when installing `upto` via `fisher`.